### PR TITLE
Lifecycles toevoegen

### DIFF
--- a/backend/app/clients/zaken.py
+++ b/backend/app/clients/zaken.py
@@ -1,9 +1,10 @@
-import httpx
 import time
+
+import httpx
+from app.config import settings
+from app.models import Zaak
 from jose import jwt
 from jose.constants import ALGORITHMS
-from app.models import Zaak
-from app.config import settings
 from pydantic import TypeAdapter
 
 

--- a/backend/app/clients/zaken.py
+++ b/backend/app/clients/zaken.py
@@ -13,9 +13,7 @@ class ZakenClient:
         self.user_id = user_id
         self.user_representation = user_representation
 
-    def get_zaken(
-            self, path: str = "zaken/api/v1/zaken", page: int = 1
-    ) -> list[Zaak]:
+    def get_zaken(self, path: str = "zaken/api/v1/zaken", page: int = 1) -> list[Zaak]:
         payload = {
             "iss": settings.OPENZAAK_CLIENT_ID,
             "iat": int(time.time()),  # current time in seconds
@@ -26,11 +24,14 @@ class ZakenClient:
         jwt_token = jwt.encode(payload, settings.OPENZAAK_SECRET, algorithm=ALGORITHMS.HS256)
 
         client = httpx.Client(
-            headers={"Authorization": f"Bearer {jwt_token}", "Content-Type": "application/json", "Accept-Crs": "EPSG:4326"}
+            headers={
+                "Authorization": f"Bearer {jwt_token}",
+                "Content-Type": "application/json",
+                "Accept-Crs": "EPSG:4326",
+            }
         )
 
         url = httpx.URL(f"{self.base_url}/{path}", params={"page": page, "ordering": "startdatum"})
-
 
         response = client.request("GET", url)
         if response.status_code != 200:

--- a/backend/app/models/zaak.py
+++ b/backend/app/models/zaak.py
@@ -2,8 +2,6 @@ from datetime import date
 
 from pydantic import BaseModel
 
-from app.config import settings
-
 
 class Zaak(BaseModel):
     uuid: str

--- a/backend/app/routes/zaken.py
+++ b/backend/app/routes/zaken.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Request
 
 from app.clients.zaken import ZakenClient
 from app.config import settings
-from app.models import Zaak, User
+from app.models import User, Zaak
 from app.token_exchange import exchange_token
 
 logger = logging.getLogger(__name__)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,21 +10,21 @@
   },
   "dependencies": {
     "@nl-rvo/assets": "^1.0.0-alpha.360",
-    "@nl-rvo/component-library-css": "^4.4.4",
-    "@nl-rvo/design-tokens": "^1.7.1",
+    "@nl-rvo/component-library-css": "^4.5.7",
+    "@nl-rvo/design-tokens": "^1.7.3",
     "keycloak-js": "^26.1.4",
     "next": "15.2.1",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
-    "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "eslint": "^9",
+    "typescript": "^5.8.3",
+    "@types/node": "^20.17.30",
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.2",
+    "eslint": "^9.24.0",
     "eslint-config-next": "15.2.1",
-    "@eslint/eslintrc": "^3"
+    "@eslint/eslintrc": "^3.3.1"
   }
 }

--- a/frontend/src/app/components/applicatieBar.tsx
+++ b/frontend/src/app/components/applicatieBar.tsx
@@ -1,69 +1,89 @@
+import LifecycleTag from "@/app/components/lifecycleTag";
+
 const applicaties = [{
   id: 0,
   title: 'Chat',
   url: 'https://chat.la-suite.apps.digilab.network/',
   iconClass: 'rvo-icon-tekstballonnen-met-punten',
-  iconLabel: 'Tekstballonnen met punten'
+  iconLabel: 'Tekstballonnen met punten',
+  status: "In ontwikkeling",
 }, {
   id: 1,
   title: 'Meet',
   url: 'https://meet.la-suite.apps.digilab.network/',
   iconClass: 'rvo-icon-silhouet-voor-scherm-raam-met-silhouet',
-  iconLabel: 'Silhouet voor scherm met silhouet'
-}, {
-  id: 2,
-  title: 'Spread-sheets',
-  url: 'https://grist.la-suite.apps.digilab.network/',
-  iconClass: 'rvo-icon-grafiek',
-  iconLabel: 'Spread-sheets'
-}, {
-  id: 3,
-  title: 'Files',
-  url: 'https://files.la-suite.apps.digilab.network/',
-  iconClass: 'rvo-icon-map-vol-documenten',
-  iconLabel: 'Map vol documenten'
-}, {
-  id: 4,
-  title: 'Taken',
-  url: 'https://webmail.opendesk.apps.digilab.network/appsuite/#app=io.ox/tasks',
-  iconClass: 'rvo-icon-kalender-met-vinkje',
-  iconLabel: 'Kalender met vinkje'
-}, {
-  id: 5,
-  title: 'Projecten',
-  url: 'https://projects.opendesk.apps.digilab.network/auth/keycloak',
-  iconClass: 'rvo-icon-bord-met-grafieken',
-  iconLabel: 'Bord met grafieken'
-}, {
-  id: 6,
-  title: 'Kennis',
-  url: 'https://wiki.opendesk.apps.digilab.network/',
-  iconClass: 'rvo-icon-online-leren',
-  iconLabel: 'Online leren'
-}, {
-  id: 7,
-  title: 'Wacht-woord manager',
-  url: 'https://vault.la-suite.apps.digilab.network/',
-  iconClass: 'rvo-icon-sleutelbos',
-  iconLabel: 'Sleutelbos'
-}, {
-  id: 8,
-  title: 'AI assistent',
-  url: 'https://ai-assistant.la-suite.apps.digilab.network/',
-  iconClass: 'rvo-icon-half-tandwiel-half-brein',
-  iconLabel: 'Half tandwiel half brein'
-}, {
-  id: 9,
-  title: 'Kalender',
-  url: 'https://webmail.opendesk.apps.digilab.network/appsuite/#app=io.ox/calendar',
-  iconClass: 'rvo-icon-kalender',
-  iconLabel: 'Kalender'
+  iconLabel: 'Silhouet voor scherm met silhouet',
+  status: "In ontwikkeling",
 }, {
   id: 10,
   title: 'Docs',
   url: 'https://docs.la-suite.apps.digilab.network/',
   iconClass: 'rvo-icon-document-met-potlood',
-  iconLabel: 'Docs'
+  iconLabel: 'Document met potlood',
+  status: "In ontwikkeling",
+}, {
+  id: 2,
+  title: 'Spread-sheets',
+  url: 'https://grist.la-suite.apps.digilab.network/',
+  iconClass: 'rvo-icon-grafiek',
+  iconLabel: 'Spread-sheets',
+  status: "In ontwikkeling",
+}, {
+  id: 5,
+  title: 'Projecten',
+  url: 'https://projects.opendesk.apps.digilab.network/auth/keycloak',
+  iconClass: 'rvo-icon-bord-met-grafieken',
+  iconLabel: 'Bord met grafieken',
+  status: "In ontwikkeling",
+}, {
+  id: 6,
+  title: 'Kennis',
+  url: 'https://wiki.opendesk.apps.digilab.network/',
+  iconClass: 'rvo-icon-online-leren',
+  iconLabel: 'Online leren',
+  status: "In ontwikkeling",
+}, {
+  id: 7,
+  title: 'Wacht-woord manager',
+  url: 'https://vault.la-suite.apps.digilab.network/',
+  iconClass: 'rvo-icon-sleutelbos',
+  iconLabel: 'Sleutelbos',
+  status: "In ontwikkeling",
+}, {
+  id: 8,
+  title: 'AI assistent',
+  url: 'https://ai-assistant.la-suite.apps.digilab.network/',
+  iconClass: 'rvo-icon-half-tandwiel-half-brein',
+  iconLabel: 'Half tandwiel half brein',
+  status: "In ontwikkeling",
+}, {
+  id: 9,
+  title: 'OpenZaak',
+  url: 'https://open-zaak.commonground.apps.digilab.network/',
+  iconClass: 'rvo-icon-map-met-loep',
+  iconLabel: 'Map met loep',
+  status: "In ontwikkeling",
+}, {
+  id: 3,
+  title: 'Files',
+  url: 'https://files.la-suite.apps.digilab.network/',
+  iconClass: 'rvo-icon-map-vol-documenten',
+  iconLabel: 'Map vol documenten',
+  status: "In ontwikkeling",
+}, {
+  id: 11,
+  title: 'Kalender',
+  url: 'https://webmail.opendesk.apps.digilab.network/appsuite/#app=io.ox/calendar',
+  iconClass: 'rvo-icon-kalender',
+  iconLabel: 'Kalender',
+  status: "In ontwikkeling",
+}, {
+  id: 4,
+  title: 'Taken',
+  url: 'https://webmail.opendesk.apps.digilab.network/appsuite/#app=io.ox/tasks',
+  iconClass: 'rvo-icon-kalender-met-vinkje',
+  iconLabel: 'Kalender met vinkje',
+  status: "In ontwikkeling",
 }];
 
 export default function ApplicatieBar() {
@@ -82,6 +102,7 @@ export default function ApplicatieBar() {
             aria-label={applicatie.iconLabel}
           ></span>
           </div>
+          <LifecycleTag status={'In ontwikkeling'} mode={'short'}/>
           <div>
             {applicatie.title}
           </div>

--- a/frontend/src/app/components/applicatieBar.tsx
+++ b/frontend/src/app/components/applicatieBar.tsx
@@ -1,89 +1,98 @@
 import LifecycleTag from "@/app/components/lifecycleTag";
 
-const applicaties = [{
+interface Applicatie  {
+  id: number,
+  title: string,
+  url: string,
+  iconClass: string,
+  iconLabel: string,
+  status: 'In ontwikkeling' | 'Proef' | 'Productie'
+}
+
+const applicaties: Applicatie[] = [{
   id: 0,
   title: 'Chat',
   url: 'https://chat.la-suite.apps.digilab.network/',
   iconClass: 'rvo-icon-tekstballonnen-met-punten',
   iconLabel: 'Tekstballonnen met punten',
-  status: "In ontwikkeling",
+  status: 'In ontwikkeling',
 }, {
   id: 1,
   title: 'Meet',
   url: 'https://meet.la-suite.apps.digilab.network/',
   iconClass: 'rvo-icon-silhouet-voor-scherm-raam-met-silhouet',
   iconLabel: 'Silhouet voor scherm met silhouet',
-  status: "In ontwikkeling",
+  status: 'In ontwikkeling',
 }, {
   id: 10,
   title: 'Docs',
   url: 'https://docs.la-suite.apps.digilab.network/',
   iconClass: 'rvo-icon-document-met-potlood',
   iconLabel: 'Document met potlood',
-  status: "In ontwikkeling",
+  status: 'In ontwikkeling',
 }, {
   id: 2,
   title: 'Spread-sheets',
   url: 'https://grist.la-suite.apps.digilab.network/',
   iconClass: 'rvo-icon-grafiek',
   iconLabel: 'Spread-sheets',
-  status: "In ontwikkeling",
+  status: 'In ontwikkeling',
 }, {
   id: 5,
   title: 'Projecten',
   url: 'https://projects.opendesk.apps.digilab.network/auth/keycloak',
   iconClass: 'rvo-icon-bord-met-grafieken',
   iconLabel: 'Bord met grafieken',
-  status: "In ontwikkeling",
+  status: 'In ontwikkeling',
 }, {
   id: 6,
   title: 'Kennis',
   url: 'https://wiki.opendesk.apps.digilab.network/',
   iconClass: 'rvo-icon-online-leren',
   iconLabel: 'Online leren',
-  status: "In ontwikkeling",
+  status: 'In ontwikkeling',
 }, {
   id: 7,
   title: 'Wacht-woord manager',
   url: 'https://vault.la-suite.apps.digilab.network/',
   iconClass: 'rvo-icon-sleutelbos',
   iconLabel: 'Sleutelbos',
-  status: "In ontwikkeling",
+  status: 'In ontwikkeling',
 }, {
   id: 8,
   title: 'AI assistent',
   url: 'https://ai-assistant.la-suite.apps.digilab.network/',
   iconClass: 'rvo-icon-half-tandwiel-half-brein',
   iconLabel: 'Half tandwiel half brein',
-  status: "In ontwikkeling",
+  status: 'In ontwikkeling',
 }, {
   id: 9,
   title: 'OpenZaak',
   url: 'https://open-zaak.commonground.apps.digilab.network/',
   iconClass: 'rvo-icon-map-met-loep',
   iconLabel: 'Map met loep',
-  status: "In ontwikkeling",
+  status: 'In ontwikkeling',
 }, {
   id: 3,
   title: 'Files',
   url: 'https://files.la-suite.apps.digilab.network/',
   iconClass: 'rvo-icon-map-vol-documenten',
   iconLabel: 'Map vol documenten',
-  status: "In ontwikkeling",
+  status: 'In ontwikkeling',
 }, {
   id: 11,
   title: 'Kalender',
   url: 'https://webmail.opendesk.apps.digilab.network/appsuite/#app=io.ox/calendar',
   iconClass: 'rvo-icon-kalender',
   iconLabel: 'Kalender',
-  status: "In ontwikkeling",
+  status: 'In ontwikkeling',
 }, {
   id: 4,
   title: 'Taken',
   url: 'https://webmail.opendesk.apps.digilab.network/appsuite/#app=io.ox/tasks',
   iconClass: 'rvo-icon-kalender-met-vinkje',
   iconLabel: 'Kalender met vinkje',
-  status: "In ontwikkeling",
+  status: 'In ontwikkeling',
 }];
 
 export default function ApplicatieBar() {
@@ -102,7 +111,7 @@ export default function ApplicatieBar() {
             aria-label={applicatie.iconLabel}
           ></span>
           </div>
-          <LifecycleTag status={'In ontwikkeling'} mode={'short'}/>
+          <LifecycleTag status={applicatie.status} mode={'short'}/>
           <div>
             {applicatie.title}
           </div>

--- a/frontend/src/app/components/lifecycleTag.tsx
+++ b/frontend/src/app/components/lifecycleTag.tsx
@@ -1,0 +1,32 @@
+export default function LifecycleTag({ status, mode }: { status: 'Productie' | 'In ontwikkeling' | 'Proef', mode: 'short' | 'long' }) {
+  if (status === 'Productie') {
+    return;
+  }
+
+  const tagType = status === 'In ontwikkeling' ? 'warning' : 'info';
+  const tagIcon = status === 'In ontwikkeling' ? 'rvo-icon-kist-met-hamer-en-moersleutel' : 'rvo-icon-tandwielen';
+  const tagIconLabel = status === 'In ontwikkeling' ? 'Kist met hamer en moersleutel' : 'Tandwielen';
+
+  if (mode === 'short') {
+    return (
+      <div title={status} className={'rvo-tag rvo-tag--with-icon rvo-tag--' + tagType}>
+            <span
+              className={'utrecht-icon rvo-icon ' + tagIcon + ' rvo-icon--md rvo-link__icon--before rvo-margin-inline-start--xs'}
+              role="img"
+              aria-label={tagIconLabel}
+            ></span>
+      </div>
+    )
+  } else {
+    return (
+      <div className={'rvo-tag rvo-tag--with-icon rvo-tag--' + tagType + ' rvo-text--sm rvo-margin-inline-start--sm openbsw-lifecycle-long'}>
+          <span
+            className={'utrecht-icon rvo-icon ' + tagIcon + ' rvo-icon--md rvo-link__icon--before'}
+            role="img"
+            aria-label={tagIconLabel}
+          ></span>
+        {status}
+    </div>
+    )
+  }
+}

--- a/frontend/src/app/components/mijnDocumenten.tsx
+++ b/frontend/src/app/components/mijnDocumenten.tsx
@@ -4,6 +4,7 @@ import {useContext, useEffect, useState} from "react";
 import {keycloak} from "../auth/keycloak";
 import {KeycloakContext} from "../auth/KeycloakProvider";
 import FileTypeIcon from "./fileTypeIcon";
+import LifecycleTag from "@/app/components/lifecycleTag";
 
 interface MijnDocumentenItemsProps {
   baseUrl?: string
@@ -93,7 +94,8 @@ interface MijnDocumentenProps {
 export default function MijnDocumenten({baseUrl}: MijnDocumentenProps) {
   return (
     <div className="openbsw-panel">
-      <h4>Mijn documenten</h4>
+      <LifecycleTag status={'In ontwikkeling'} mode={'long'}/>
+      <h4>Mijn files</h4>
       {/*<ul*/}
       {/*  className="rvo-tabs rvo-ul rvo-ul--no-margin rvo-ul--no-padding rvo-ul--icon rvo-ul--icon-option-2 openbsw-tabs"*/}
       {/*  role="tablist"*/}

--- a/frontend/src/app/components/mijnDossiers.tsx
+++ b/frontend/src/app/components/mijnDossiers.tsx
@@ -3,6 +3,7 @@
 import {useContext, useEffect, useState} from "react";
 import {keycloak} from "../auth/keycloak";
 import {KeycloakContext} from "../auth/KeycloakProvider";
+import LifecycleTag from "@/app/components/lifecycleTag";
 
 interface MijnDossiersItemsProps {
   baseUrl: string
@@ -92,6 +93,7 @@ interface MijnDossiersProps {
 export default function MijnDossiers({baseUrl}: MijnDossiersProps) {
   return (
     <div className="openbsw-panel">
+      <LifecycleTag status={'In ontwikkeling'} mode={'long'}/>
       <h4>Mijn dossiers</h4>
       <div className="rvo-scrollable-content openbsw-panel-scrollable-content">
         <MijnDossiersItems baseUrl={baseUrl}></MijnDossiersItems>

--- a/frontend/src/app/components/mijnKalender.tsx
+++ b/frontend/src/app/components/mijnKalender.tsx
@@ -3,6 +3,7 @@
 import {useContext, useEffect, useState} from "react";
 import {keycloak} from "../auth/keycloak";
 import {KeycloakContext} from "../auth/KeycloakProvider";
+import LifecycleTag from "@/app/components/lifecycleTag";
 
 interface MijnKalenderItemsProps {
   baseUrl: string
@@ -97,6 +98,7 @@ export default function MijnKalender({baseUrl}: MijnKalenderProps) {
   const toTimestamp = nextHour.setHours(nextHour.getHours() + 1).valueOf() / 1000;
   return (
     <div className="openbsw-panel">
+      <LifecycleTag status={'In ontwikkeling'} mode={'long'}/>
       <h4>Agenda van vandaag</h4>
       <div className="rvo-scrollable-content openbsw-panel-scrollable-content">
         <MijnKalenderItems baseUrl={baseUrl}></MijnKalenderItems>

--- a/frontend/src/app/components/mijnTaken.tsx
+++ b/frontend/src/app/components/mijnTaken.tsx
@@ -3,6 +3,7 @@
 import {useContext, useEffect, useState} from "react";
 import {keycloak} from "../auth/keycloak";
 import {KeycloakContext} from "../auth/KeycloakProvider";
+import LifecycleTag from "@/app/components/lifecycleTag";
 
 interface TakenItemsData {
   url: string,
@@ -107,6 +108,7 @@ interface MijnTakenProps {
 export default function MijnTaken({baseUrl}: MijnTakenProps) {
   return (
     <div className="openbsw-panel">
+      <LifecycleTag status={'In ontwikkeling'} mode={'long'}/>
       <h4>Mijn taken</h4>
       <div className="rvo-scrollable-content openbsw-panel-scrollable-content">
         <MijnTakenItems baseUrl={baseUrl}></MijnTakenItems>

--- a/frontend/src/app/components/mijnZaken.tsx
+++ b/frontend/src/app/components/mijnZaken.tsx
@@ -3,6 +3,7 @@
 import {useContext, useEffect, useState} from "react";
 import {keycloak} from "../auth/keycloak";
 import {KeycloakContext} from "../auth/KeycloakProvider";
+import LifecycleTag from "@/app/components/lifecycleTag";
 
 interface MijnZakenItemsProps {
   baseUrl: string
@@ -92,6 +93,7 @@ interface MijnZakenProps {
 export default function MijnZaken({baseUrl}: MijnZakenProps) {
   return (
     <div className="openbsw-panel">
+      <LifecycleTag status={'In ontwikkeling'} mode={'long'}/>
       <h4>Mijn zaken</h4>
       <div className="rvo-scrollable-content openbsw-panel-scrollable-content">
         <MijnZakenItems baseUrl={baseUrl}></MijnZakenItems>

--- a/frontend/src/app/components/updates.tsx
+++ b/frontend/src/app/components/updates.tsx
@@ -2,6 +2,7 @@
 
 import {useEffect, useState} from "react";
 import {valueOrEmptyString} from "../page";
+import LifecycleTag from "@/app/components/lifecycleTag";
 
 interface UpdateItemsData {
   title: string,
@@ -89,6 +90,7 @@ function UpdatesItems() {
 export default function Updates() {
   return (
     <div className="openbsw-panel">
+      <LifecycleTag status={'In ontwikkeling'} mode={'long'}/>
       <h4>Updates</h4>
       <div className="rvo-scrollable-content openbsw-panel-scrollable-content">
         <UpdatesItems></UpdatesItems>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -41,6 +41,7 @@
     margin-top: var(--rvo-space-md);
     margin-bottom: var(--rvo-space-md);
     background-color: var(--rvo-color-wit);
+    gap: 28px;
 }
 .openbsw-applicatie-bar-head {
     text-align: end;
@@ -74,7 +75,7 @@
     width: 50px;
     height: 50px;
     padding: var(--rvo-space-sm);
-    margin-left: var(--rvo-space-2xs);
+    /*margin-left: var(--rvo-space-2xs);*/
     background-color: var(--rvo-color-hemelblauw-150);
 }
 
@@ -99,6 +100,11 @@
 .openbsw-panel-scrollable-content {
     max-height: 200px;
     min-height: 200px
+}
+.openbsw-lifecycle-long {
+    float: right;
+    padding-block-start: 2px;
+    padding-block-end: 2px;
 }
 
 .openbsw-tabs {


### PR DESCRIPTION
# Description

Met tags wordt nu aangegeven in welke lifecycle een product zich bevindt. Voor de applicatie bar is hier een koppeling met de applicatie-data. Dit is niet gebruikt voor de panels, daar is het nog handmatig geconfigureerd.

![image](https://github.com/user-attachments/assets/1873f210-f865-4109-89bc-452c7ab3626a)
