### PR TITLE
🐛(backend) fix login session

### DIFF
--- a/backend/app/core/authentication.py
+++ b/backend/app/core/authentication.py
@@ -33,6 +33,10 @@ async def get_current_user(
     if not auth:
         raise CredentialError(_("Not authenticated"))
 
+    if not auth.expires_at:
+        logger.warning("Auth state missing expires_at, treating as expired")
+        raise CredentialError(_("Session expired. Please log in again."))
+
     if _needs_refresh(auth.expires_at):
         await _refresh_token(request, auth.refresh_token)
 
@@ -41,7 +45,6 @@ async def get_current_user(
         if not auth:
             raise CredentialError(_("Session expired. Please log in again."))
 
-    request.state.user = auth.user
     return auth.user
 
 

--- a/backend/app/routes/authentication.py
+++ b/backend/app/routes/authentication.py
@@ -1,11 +1,12 @@
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import RedirectResponse
 from starlette.datastructures import URL
 
 from app.core import session
+from app.core.authentication import get_current_user
 from app.core.config import settings
 from app.core.oauth import oauth
 from app.core.translate import _
@@ -61,7 +62,7 @@ async def callback(request: Request) -> RedirectResponse:
         return RedirectResponse(url=f"/login?error={error_message}", status_code=302)
 
 
-@router.get("/profile")
+@router.get("/profile", dependencies=[Depends(get_current_user)])
 async def profile(request: Request) -> User:
     """Get current user profile from session."""
     auth = await session.get_auth(request)

--- a/backend/tests/core/test_authentication.py
+++ b/backend/tests/core/test_authentication.py
@@ -62,7 +62,6 @@ class TestRefreshToken:
         """Create a mock request object."""
         request = MagicMock(spec=Request)
         request.session = {}
-        request.state = MagicMock()
         return request
 
     @pytest.mark.asyncio
@@ -214,7 +213,6 @@ class TestGetCurrentUser:
         """Create a mock request object."""
         request = MagicMock(spec=Request)
         request.session = {"_session_id": "test_session_123"}
-        request.state = MagicMock()
         return request
 
     @pytest.fixture
@@ -267,7 +265,6 @@ class TestGetCurrentUser:
         result = await get_current_user(mock_request, None)
 
         assert result == valid_auth_state.user
-        assert mock_request.state.user == valid_auth_state.user
         # Should not attempt refresh
         mock_session.update_tokens.assert_not_called()
 
@@ -299,7 +296,6 @@ class TestGetCurrentUser:
 
         # Verify result
         assert result == valid_auth_state.user
-        assert mock_request.state.user == valid_auth_state.user
 
     @pytest.mark.asyncio
     @patch("app.core.authentication.session")
@@ -384,7 +380,6 @@ class TestGetCurrentUser:
         # Create request without session ID
         request = MagicMock(spec=Request)
         request.session = {}  # No _session_id
-        request.state = MagicMock()
 
         mock_session.get_auth.side_effect = [
             expired_auth_state,  # Initial check


### PR DESCRIPTION
# Description

Session is lost sometimes on bureaublad. this keeps the session alive. It is not the most efficient fix because profile endpoint now queries redis 2 times for the same information.

It also does not fix the core issue. still investigating the core issue. this is a symptom fix that implicitly solves the real problem.  



Resolves #413

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have updated documentation.
